### PR TITLE
feat(rustdoc): indicate unstable items in search results and sidebar

### DIFF
--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -594,6 +594,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
     );
     let aliases = item.attrs.get_doc_aliases();
     let deprecation = item.deprecation(tcx);
+    let is_unstable = item.stability(tcx).map_or(false, |stab| stab.is_unstable());
     let index_item = IndexItem {
         ty: item.type_(),
         defid: Some(defid),
@@ -609,6 +610,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         search_type,
         aliases,
         deprecation,
+        is_unstable,
     };
 
     cache.search_index.push(index_item);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -142,6 +142,7 @@ pub(crate) struct IndexItem {
     pub(crate) search_type: Option<IndexItemFunctionType>,
     pub(crate) aliases: Box<[Symbol]>,
     pub(crate) deprecation: Option<Deprecation>,
+    pub(crate) is_unstable: bool,
 }
 
 /// A type used for the search index.

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -243,6 +243,7 @@ declare namespace rustdoc {
         parent: number?,
         traitParent: number?,
         deprecated: boolean,
+        isUnstable: boolean,
         associatedItemDisambiguator: string?,
     }
 
@@ -292,6 +293,7 @@ declare namespace rustdoc {
         path: PathData?,
         functionData: FunctionData?,
         deprecated: boolean,
+        isUnstable: boolean,
         parent: RowParent,
         traitParent: RowParent,
     }

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1633,10 +1633,12 @@ class DocSearch {
          * parent,
          * trait_parent,
          * deprecated,
+         * is_unstable,
          * associated_item_disambiguator
          * @type {rustdoc.ArrayWithOptionals<[
          *     number,
          *     rustdoc.ItemType,
+         *     number,
          *     number,
          *     number,
          *     number,
@@ -1653,7 +1655,8 @@ class DocSearch {
             parent: raw[4] === 0 ? null : raw[4] - 1,
             traitParent: raw[5] === 0 ? null : raw[5] - 1,
             deprecated: raw[6] === 1 ? true : false,
-            associatedItemDisambiguator: raw.length === 7 ? null : raw[7],
+            isUnstable: raw[7] === 1 ? true : false,
+            associatedItemDisambiguator: raw.length === 8 ? null : raw[8],
         };
     }
 
@@ -1946,6 +1949,7 @@ class DocSearch {
             path,
             functionData,
             deprecated: entry ? entry.deprecated : false,
+            isUnstable: entry ? entry.isUnstable : false,
             parent,
             traitParent,
         };
@@ -4936,10 +4940,16 @@ async function addTab(results, query, display, finishedCallback, isTypeSearch) {
 <b>${obj.alias}</b><i class="grey">&nbsp;- see&nbsp;</i>\
 </div>`;
         }
+        const unstableBadge = obj.item.isUnstable ?
+            "<span class=\"stab unstable\" title=\"This is a nightly-only experimental API.\">\
+🔬\
+</span>"
+            : "";
         resultName.insertAdjacentHTML(
             "beforeend",
             `<div class="path">${alias}\
 ${obj.displayPath}<span class="${type}">${name}</span>\
+${unstableBadge ? " " + unstableBadge : ""}\
 </div>`);
 
         const description = document.createElement("div");

--- a/src/librustdoc/html/templates/sidebar.html
+++ b/src/librustdoc/html/templates/sidebar.html
@@ -30,6 +30,9 @@
                                             {% else %}
                                                 {{link.name}}
                                         {% endmatch %}
+                                        {% if link.is_unstable %}
+                                            {# +#} <span class="stab unstable" title="This is a nightly-only experimental API.">🔬</span>
+                                        {% endif %}
                                     </a>
                                     {% if !link.children.is_empty() %}
                                         <ul>


### PR DESCRIPTION
Right now it is hard to tell whether items are unstable but after this pr it makes it much clearer:

<img width="2494" height="1815" alt="image" src="https://github.com/user-attachments/assets/f13a401c-2799-43a1-9df3-63c91de0bd47" />

I think we could also do something similar with deprecated items if that would be useful :)

Closes #4
