### PR TITLE
refactor(borrowck): less cloning in `compute_closure_requirements_modulo_opaques`

### DIFF
--- a/compiler/rustc_borrowck/src/handle_placeholders.rs
+++ b/compiler/rustc_borrowck/src/handle_placeholders.rs
@@ -264,7 +264,7 @@ pub(super) fn region_definitions<'tcx>(
 /// Every constraint added by this method is an internal `IllegalUniverse` constraint.
 pub(crate) fn compute_sccs_applying_placeholder_outlives_constraints<'tcx>(
     constraints: MirTypeckRegionConstraints<'tcx>,
-    universal_region_relations: &Frozen<UniversalRegionRelations<'tcx>>,
+    universal_region_relations: &UniversalRegionRelations<'tcx>,
     infcx: &BorrowckInferCtxt<'tcx>,
 ) -> LoweredConstraints<'tcx> {
     let universal_regions = &universal_region_relations.universal_regions;

--- a/compiler/rustc_borrowck/src/handle_placeholders.rs
+++ b/compiler/rustc_borrowck/src/handle_placeholders.rs
@@ -8,7 +8,7 @@ use rustc_data_structures::graph::scc::Sccs;
 use rustc_index::IndexVec;
 use rustc_infer::infer::RegionVariableOrigin;
 use rustc_middle::mir::ConstraintCategory;
-use rustc_middle::ty::{RegionVid, UniverseIndex};
+use rustc_middle::ty::{self, RegionVid, UniverseIndex};
 use tracing::{debug, trace};
 
 use crate::constraints::{ConstraintSccIndex, OutlivesConstraintSet};
@@ -17,8 +17,8 @@ use crate::diagnostics::UniverseInfo;
 use crate::region_infer::values::{LivenessValues, PlaceholderIndices};
 use crate::region_infer::{ConstraintSccs, RegionDefinition, Representative, TypeTest};
 use crate::ty::VarianceDiagInfo;
+use crate::type_check::Locations;
 use crate::type_check::free_region_relations::UniversalRegionRelations;
-use crate::type_check::{Locations, MirTypeckRegionConstraints};
 use crate::universal_regions::UniversalRegions;
 use crate::{BorrowckInferCtxt, NllRegionVariableOrigin};
 
@@ -263,21 +263,16 @@ pub(super) fn region_definitions<'tcx>(
 ///
 /// Every constraint added by this method is an internal `IllegalUniverse` constraint.
 pub(crate) fn compute_sccs_applying_placeholder_outlives_constraints<'tcx>(
-    constraints: MirTypeckRegionConstraints<'tcx>,
+    placeholder_indices: PlaceholderIndices<'tcx>,
+    liveness_constraints: LivenessValues,
+    mut outlives_constraints: OutlivesConstraintSet<'tcx>,
+    universe_causes: FxIndexMap<ty::UniverseIndex, UniverseInfo<'tcx>>,
+    type_tests: Vec<TypeTest<'tcx>>,
     universal_region_relations: &UniversalRegionRelations<'tcx>,
     infcx: &BorrowckInferCtxt<'tcx>,
 ) -> LoweredConstraints<'tcx> {
     let universal_regions = &universal_region_relations.universal_regions;
     let (definitions, has_placeholders) = region_definitions(infcx, universal_regions);
-
-    let MirTypeckRegionConstraints {
-        placeholder_indices,
-        placeholder_index_to_region: _,
-        liveness_constraints,
-        mut outlives_constraints,
-        universe_causes,
-        type_tests,
-    } = constraints;
 
     let fr_static = universal_regions.fr_static;
     let compute_sccs =

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -293,7 +293,7 @@ struct CollectRegionConstraintsResult<'tcx> {
     borrow_set: BorrowSet<'tcx>,
     location_table: PoloniusLocationTable,
     location_map: Rc<DenseLocationMap>,
-    universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
+    universal_region_relations: Rc<UniversalRegionRelations<'tcx>>,
     region_bound_pairs: Frozen<RegionBoundPairs<'tcx>>,
     known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesPredicate<'tcx>>>,
     constraints: MirTypeckRegionConstraints<'tcx>,

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -6,7 +6,6 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use polonius_engine::{Algorithm, AllFacts, Output};
-use rustc_data_structures::frozen::Frozen;
 use rustc_index::IndexSlice;
 use rustc_middle::mir::pretty::PrettyPrintMirOptions;
 use rustc_middle::mir::{Body, MirDumper, PassWhere, Promoted};
@@ -86,7 +85,7 @@ pub(crate) fn compute_closure_requirements_modulo_opaques<'tcx>(
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     location_map: Rc<DenseLocationMap>,
-    universal_region_relations: &Frozen<UniversalRegionRelations<'tcx>>,
+    universal_region_relations: Rc<UniversalRegionRelations<'tcx>>,
     constraints: &MirTypeckRegionConstraints<'tcx>,
 ) -> Option<ClosureRegionRequirements<'tcx>> {
     // FIXME(#146079): we shouldn't have to clone all this stuff here.
@@ -99,7 +98,7 @@ pub(crate) fn compute_closure_requirements_modulo_opaques<'tcx>(
     let mut regioncx = RegionInferenceContext::new(
         &infcx,
         lowered_constraints,
-        universal_region_relations.clone(),
+        universal_region_relations,
         location_map,
     );
 
@@ -118,7 +117,7 @@ pub(crate) fn compute_regions<'tcx>(
     move_data: &MoveData<'tcx>,
     borrow_set: &BorrowSet<'tcx>,
     location_map: Rc<DenseLocationMap>,
-    universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
+    universal_region_relations: Rc<UniversalRegionRelations<'tcx>>,
     constraints: MirTypeckRegionConstraints<'tcx>,
     mut polonius_facts: Option<AllFacts<RustcFacts>>,
     polonius_context: Option<PoloniusContext>,

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -86,12 +86,16 @@ pub(crate) fn compute_closure_requirements_modulo_opaques<'tcx>(
     body: &Body<'tcx>,
     location_map: Rc<DenseLocationMap>,
     universal_region_relations: Rc<UniversalRegionRelations<'tcx>>,
-    constraints: &MirTypeckRegionConstraints<'tcx>,
-) -> Option<ClosureRegionRequirements<'tcx>> {
-    // FIXME(#146079): we shouldn't have to clone all this stuff here.
-    // Computing the region graph should take at least some of it by reference/`Rc`.
+    constraints: MirTypeckRegionConstraints<'tcx>,
+) -> (MirTypeckRegionConstraints<'tcx>, Option<ClosureRegionRequirements<'tcx>>) {
+    let outlives_constraints = constraints.outlives_constraints.clone();
+
     let lowered_constraints = compute_sccs_applying_placeholder_outlives_constraints(
-        constraints.clone(),
+        constraints.placeholder_indices,
+        constraints.liveness_constraints,
+        outlives_constraints,
+        constraints.universe_causes,
+        constraints.type_tests,
         &universal_region_relations,
         infcx,
     );
@@ -103,7 +107,17 @@ pub(crate) fn compute_closure_requirements_modulo_opaques<'tcx>(
     );
 
     let (closure_region_requirements, _nll_errors) = regioncx.solve(infcx, body, None);
-    closure_region_requirements
+    (
+        MirTypeckRegionConstraints {
+            placeholder_indices: regioncx.scc_values.placeholder_indices,
+            placeholder_index_to_region: constraints.placeholder_index_to_region,
+            liveness_constraints: regioncx.liveness_constraints,
+            outlives_constraints: constraints.outlives_constraints,
+            universe_causes: regioncx.universe_causes,
+            type_tests: regioncx.type_tests,
+        },
+        closure_region_requirements,
+    )
 }
 
 /// Computes the (non-lexical) regions from the input MIR.
@@ -126,7 +140,11 @@ pub(crate) fn compute_regions<'tcx>(
         || infcx.tcx.sess.opts.unstable_opts.polonius.is_legacy_enabled();
 
     let lowered_constraints = compute_sccs_applying_placeholder_outlives_constraints(
-        constraints,
+        constraints.placeholder_indices,
+        constraints.liveness_constraints,
+        constraints.outlives_constraints,
+        constraints.universe_causes,
+        constraints.type_tests,
         &universal_region_relations,
         infcx,
     );

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -117,7 +117,7 @@ pub struct RegionInferenceContext<'tcx> {
 
     /// Information about how the universally quantified regions in
     /// scope on this function relate to one another.
-    universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
+    universal_region_relations: Rc<UniversalRegionRelations<'tcx>>,
 }
 
 #[derive(Debug)]
@@ -292,7 +292,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     pub(crate) fn new(
         infcx: &BorrowckInferCtxt<'tcx>,
         lowered_constraints: LoweredConstraints<'tcx>,
-        universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
+        universal_region_relations: Rc<UniversalRegionRelations<'tcx>>,
         location_map: Rc<DenseLocationMap>,
     ) -> Self {
         let universal_regions = &universal_region_relations.universal_regions;

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -87,7 +87,7 @@ pub struct RegionInferenceContext<'tcx> {
     /// regions, these start out empty and steadily grow, though for
     /// each universally quantified region R they start out containing
     /// the entire CFG and `end(R)`.
-    liveness_constraints: LivenessValues,
+    pub(crate) liveness_constraints: LivenessValues,
 
     /// The outlives constraints computed by the type-check.
     constraints: Frozen<OutlivesConstraintSet<'tcx>>,
@@ -105,15 +105,15 @@ pub struct RegionInferenceContext<'tcx> {
     scc_annotations: IndexVec<ConstraintSccIndex, RegionTracker>,
 
     /// Map universe indexes to information on why we created it.
-    universe_causes: FxIndexMap<ty::UniverseIndex, UniverseInfo<'tcx>>,
+    pub(crate) universe_causes: FxIndexMap<ty::UniverseIndex, UniverseInfo<'tcx>>,
 
     /// The final inferred values of the region variables; we compute
     /// one value per SCC. To get the value for any given *region*,
     /// you first find which scc it is a part of.
-    scc_values: RegionValues<'tcx, ConstraintSccIndex>,
+    pub(crate) scc_values: RegionValues<'tcx, ConstraintSccIndex>,
 
     /// Type constraints that we check after solving.
-    type_tests: Vec<TypeTest<'tcx>>,
+    pub(crate) type_tests: Vec<TypeTest<'tcx>>,
 
     /// Information about how the universally quantified regions in
     /// scope on this function relate to one another.

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -1,7 +1,6 @@
 use std::iter;
 use std::rc::Rc;
 
-use rustc_data_structures::frozen::Frozen;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_infer::infer::outlives::env::RegionBoundPairs;
@@ -65,7 +64,7 @@ pub(crate) enum DeferredOpaqueTypeError<'tcx> {
 /// encounter inference variables, e.g. when checking user types.
 pub(crate) fn clone_and_resolve_opaque_types<'tcx>(
     infcx: &BorrowckInferCtxt<'tcx>,
-    universal_region_relations: &Frozen<UniversalRegionRelations<'tcx>>,
+    universal_region_relations: &UniversalRegionRelations<'tcx>,
     constraints: &mut MirTypeckRegionConstraints<'tcx>,
 ) -> (OpaqueTypeStorageEntries, Vec<(OpaqueTypeKey<'tcx>, ProvisionalHiddenType<'tcx>)>) {
     let opaque_types = infcx.clone_opaque_types();
@@ -177,7 +176,7 @@ struct DefiningUse<'tcx> {
 /// recheck all uses of the opaques regardless.
 pub(crate) fn compute_definition_site_hidden_types<'tcx>(
     infcx: &BorrowckInferCtxt<'tcx>,
-    universal_region_relations: &Frozen<UniversalRegionRelations<'tcx>>,
+    universal_region_relations: &UniversalRegionRelations<'tcx>,
     constraints: &MirTypeckRegionConstraints<'tcx>,
     location_map: Rc<DenseLocationMap>,
     hidden_types: &mut FxIndexMap<LocalDefId, ty::DefinitionSiteHiddenType<'tcx>>,

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/region_ctxt.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/region_ctxt.rs
@@ -37,7 +37,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     /// when applying member constraints.
     pub(super) fn new(
         infcx: &'a BorrowckInferCtxt<'tcx>,
-        universal_region_relations: &'a Frozen<UniversalRegionRelations<'tcx>>,
+        universal_region_relations: &'a UniversalRegionRelations<'tcx>,
         location_map: Rc<DenseLocationMap>,
         constraints: &MirTypeckRegionConstraints<'tcx>,
     ) -> RegionCtxt<'a, 'tcx> {

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -37,7 +37,6 @@ pub(crate) enum RegionElement<'tcx> {
 
 /// Records the CFG locations where each region is live. When we initially compute liveness, we use
 /// an interval matrix storing liveness ranges for each region-vid.
-#[derive(Clone)] // FIXME(#146079)
 pub(crate) struct LivenessValues {
     /// The map from locations to points.
     location_map: Rc<DenseLocationMap>,
@@ -195,7 +194,6 @@ impl LivenessValues {
 /// rustc to the internal `PlaceholderIndex` values that are used in
 /// NLL.
 #[derive(Debug, Default)]
-#[derive(Clone)] // FIXME(#146079)
 pub(crate) struct PlaceholderIndices<'tcx> {
     indices: FxIndexSet<ty::PlaceholderRegion<'tcx>>,
 }
@@ -246,7 +244,7 @@ impl<'tcx> PlaceholderIndices<'tcx> {
 /// it would also contain various points from within the function.
 pub(crate) struct RegionValues<'tcx, N: Idx> {
     location_map: Rc<DenseLocationMap>,
-    placeholder_indices: PlaceholderIndices<'tcx>,
+    pub(crate) placeholder_indices: PlaceholderIndices<'tcx>,
     points: SparseIntervalMatrix<N, PointIndex>,
     free_regions: SparseBitMatrix<N, RegionVid>,
 

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -212,7 +212,7 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
             &input.infcx,
             &input.body_owned,
             Rc::clone(&input.location_map),
-            &input.universal_region_relations,
+            Rc::clone(&input.universal_region_relations),
             &input.constraints,
         )
     }

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -193,7 +193,14 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
             // and write its result into `propagated_borrowck_results`.
             if depends_on_opaques {
                 if def_id != self.root_def_id {
-                    let req = Self::compute_closure_requirements_modulo_opaques(&input);
+                    let (constraints, req) = compute_closure_requirements_modulo_opaques(
+                        &input.infcx,
+                        &input.body_owned,
+                        Rc::clone(&input.location_map),
+                        Rc::clone(&input.universal_region_relations),
+                        input.constraints,
+                    );
+                    input.constraints = constraints;
                     closure_requirements_modulo_opaques.insert(def_id, req);
                 }
                 self.collect_region_constraints_results.insert(def_id, input);
@@ -203,18 +210,6 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
                 self.propagated_borrowck_results.insert(def_id, result);
             }
         }
-    }
-
-    fn compute_closure_requirements_modulo_opaques(
-        input: &CollectRegionConstraintsResult<'tcx>,
-    ) -> Option<ClosureRegionRequirements<'tcx>> {
-        compute_closure_requirements_modulo_opaques(
-            &input.infcx,
-            &input.body_owned,
-            Rc::clone(&input.location_map),
-            Rc::clone(&input.universal_region_relations),
-            &input.constraints,
-        )
     }
 
     fn apply_closure_requirements(

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use rustc_data_structures::frozen::Frozen;
 use rustc_data_structures::transitive_relation::{TransitiveRelation, TransitiveRelationBuilder};
 use rustc_hir::def::DefKind;
@@ -19,7 +21,6 @@ use crate::type_check::{Locations, MirTypeckRegionConstraints, constraint_conver
 use crate::universal_regions::UniversalRegions;
 
 #[derive(Debug)]
-#[derive(Clone)] // FIXME(#146079)
 pub(crate) struct UniversalRegionRelations<'tcx> {
     pub(crate) universal_regions: UniversalRegions<'tcx>,
 
@@ -42,7 +43,7 @@ pub(crate) struct UniversalRegionRelations<'tcx> {
 type NormalizedInputsAndOutput<'tcx> = Vec<Ty<'tcx>>;
 
 pub(crate) struct CreateResult<'tcx> {
-    pub(crate) universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
+    pub(crate) universal_region_relations: Rc<UniversalRegionRelations<'tcx>>,
     pub(crate) region_bound_pairs: Frozen<RegionBoundPairs<'tcx>>,
     pub(crate) known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesPredicate<'tcx>>>,
     pub(crate) normalized_inputs_and_output: NormalizedInputsAndOutput<'tcx>,
@@ -310,7 +311,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
         }
 
         CreateResult {
-            universal_region_relations: Frozen::freeze(UniversalRegionRelations {
+            universal_region_relations: Rc::new(UniversalRegionRelations {
                 universal_regions: self.universal_regions,
                 outlives: self.outlives.freeze(),
                 inverse_outlives: self.inverse_outlives.freeze(),

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -242,7 +242,7 @@ struct TypeChecker<'a, 'tcx> {
 /// inference computation.
 pub(crate) struct MirTypeckResults<'tcx> {
     pub(crate) constraints: MirTypeckRegionConstraints<'tcx>,
-    pub(crate) universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
+    pub(crate) universal_region_relations: Rc<UniversalRegionRelations<'tcx>>,
     pub(crate) region_bound_pairs: Frozen<RegionBoundPairs<'tcx>>,
     pub(crate) known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesPredicate<'tcx>>>,
     pub(crate) deferred_closure_requirements: DeferredClosureRequirements<'tcx>,

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -251,7 +251,6 @@ pub(crate) struct MirTypeckResults<'tcx> {
 
 /// A collection of region constraints that must be satisfied for the
 /// program to be considered well-typed.
-#[derive(Clone)] // FIXME(#146079)
 pub(crate) struct MirTypeckRegionConstraints<'tcx> {
     /// Maps from a `ty::Placeholder` to the corresponding
     /// `PlaceholderIndex` bit that we will use for it.

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -39,7 +39,6 @@ use crate::BorrowckInferCtxt;
 use crate::renumber::RegionCtxt;
 
 #[derive(Debug)]
-#[derive(Clone)] // FIXME(#146079)
 pub(crate) struct UniversalRegions<'tcx> {
     indices: UniversalRegionIndices<'tcx>,
 
@@ -200,7 +199,6 @@ impl<'tcx> DefiningTy<'tcx> {
 }
 
 #[derive(Debug)]
-#[derive(Clone)] // FIXME(#146079)
 struct UniversalRegionIndices<'tcx> {
     /// For those regions that may appear in the parameter environment
     /// ('static and early-bound regions), we maintain a map from the


### PR DESCRIPTION
Not too sure if this is the right solution but thought I would put up this PR as a starting point to iterate on. Looking at how the fields are used in `compute_sccs_applying_placeholder_outlives_constraints` and `RegionInferenceContext`, it seems like most can be used immutably but right now `RegionInferenceContext` expects to own these fields. 

I tried to introduce a new lifetime to `RegionInferenceContext` so we can use references instead but it seems like a bit of a pain to update each of the struct definitions it's used in. Alternatively, we could pass the fields as parameters instead of keeping them in the structs which is easy for some fields like `type_tests` but would be more work for some of the others, though I think this might be a better solution since `CollectRegionConstraintsResult` can own the fields and then use a shared reference for the duration of `compute_closure_requirements_modulo_opaques`? For now, I've just used `Rc` on these fields but this is a bit unfortunate because it requires using `Rc::get_mut` in `CollectRegionConstraintsResult` methods and shifting the check of whether another reference exists to runtime. If we decide to go forward with using `Rc`, I'll at least add a few comments mentioning that we can't have an outstanding reference when calling certain methods.

This is the local performance difference between main and this PR:

<img width="3807" height="1899" alt="Screenshot_20260111_121920" src="https://github.com/user-attachments/assets/efb5b97a-8bce-4e12-a3ff-c3e929f3ab87" />

Closes #3 