### PR TITLE
feat(diagnostics): suggest reordering fields for borrow of moved value

### DIFF
--- a/tests/ui/borrowck/borrow-moved-value-suggest-reordering-fields.rs
+++ b/tests/ui/borrowck/borrow-moved-value-suggest-reordering-fields.rs
@@ -1,0 +1,32 @@
+#![allow(dead_code)]
+
+struct Foo {
+    a: String,
+    b: usize,
+}
+
+impl Foo {
+    fn new(a: String) -> Self {
+        Self {
+            a,
+            //~^ HELP consider cloning the value if the performance cost is acceptable
+            //~| HELP consider initializing `b` before `a`
+            b: a.len(),
+            //~^ ERROR borrow of moved value
+        }
+    }
+
+    fn dont_suggest_within_same_field_init(a: String) -> Self {
+        Self {
+            a: String::new(),
+            b: {
+                let b = a;
+                //~^ HELP consider cloning the value if the performance cost is acceptable
+                a.len()
+                //~^ ERROR borrow of moved value
+            },
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/borrowck/borrow-moved-value-suggest-reordering-fields.stderr
+++ b/tests/ui/borrowck/borrow-moved-value-suggest-reordering-fields.stderr
@@ -1,0 +1,44 @@
+error[E0382]: borrow of moved value: `a`
+  --> $DIR/borrow-moved-value-suggest-reordering-fields.rs:14:16
+   |
+LL |     fn new(a: String) -> Self {
+   |            - move occurs because `a` has type `String`, which does not implement the `Copy` trait
+LL |         Self {
+LL |             a,
+   |             - value moved here
+...
+LL |             b: a.len(),
+   |                ^ value borrowed here after move
+   |
+help: consider initializing `b` before `a`
+   |
+LL ~             b: a.len(),
+LL |
+LL |
+LL ~             a,
+   |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |             a: a.clone(),
+   |              +++++++++++
+
+error[E0382]: borrow of moved value: `a`
+  --> $DIR/borrow-moved-value-suggest-reordering-fields.rs:25:17
+   |
+LL |     fn dont_suggest_overlapping_span_fields(a: String) -> Self {
+   |                                             - move occurs because `a` has type `String`, which does not implement the `Copy` trait
+...
+LL |                 let b = a;
+   |                         - value moved here
+LL |
+LL |                 a.len()
+   |                 ^ value borrowed here after move
+   |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |                 let b = a.clone();
+   |                          ++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/borrowck/copy-suggestion-region-vid.fixed
+++ b/tests/ui/borrowck/copy-suggestion-region-vid.fixed
@@ -1,4 +1,5 @@
 //@ run-rustfix
+//@ rustfix-only-machine-applicable
 pub struct DataStruct();
 
 pub struct HelperStruct<'n> {

--- a/tests/ui/borrowck/copy-suggestion-region-vid.rs
+++ b/tests/ui/borrowck/copy-suggestion-region-vid.rs
@@ -1,4 +1,5 @@
 //@ run-rustfix
+//@ rustfix-only-machine-applicable
 pub struct DataStruct();
 
 pub struct HelperStruct<'n> {

--- a/tests/ui/borrowck/copy-suggestion-region-vid.stderr
+++ b/tests/ui/borrowck/copy-suggestion-region-vid.stderr
@@ -1,5 +1,5 @@
 error[E0382]: borrow of moved value: `helpers`
-  --> $DIR/copy-suggestion-region-vid.rs:13:43
+  --> $DIR/copy-suggestion-region-vid.rs:14:43
    |
 LL |         let helpers = [vec![], vec![]];
    |             ------- move occurs because `helpers` has type `[Vec<&i64>; 2]`, which does not implement the `Copy` trait
@@ -8,6 +8,11 @@ LL |         HelperStruct { helpers, is_empty: helpers[0].is_empty() }
    |                        -------            ^^^^^^^^^^ value borrowed here after move
    |                        |
    |                        value moved here
+   |
+help: consider initializing `is_empty` before `helpers`
+   |
+LL -         HelperStruct { helpers, is_empty: helpers[0].is_empty() }
+LL +         HelperStruct { is_empty: helpers[0].is_empty(), helpers }
    |
 help: consider cloning the value if the performance cost is acceptable
    |


### PR DESCRIPTION
If a moved value and a borrow from it are both within struct initializer fields then it may be possible to reorder them to avoid cloning. I'm not sure if this always works but I couldn't think of any counter examples off the top of my head for the simple one borrow case. If we have multiple borrows:

```rust
struct Foo {
    a: String,
    b: usize,
    c: usize,
}

impl Foo {
    fn new(a: String) -> Self {
        Self {
            a,
            b: a.len(),
            c: a.len(),
        }
    }
}
```

Then only one diagnostic is shown at a time, first for `b` and then after for `c`. It would probably be nice to show all in one diagnostic that both `b` and `c` should go before `a` here but I'm not entirely sure how to go about that. As an alternative we could probably also suggest extracting the borrow usages to local variables before the struct initializer.

Closes #6 